### PR TITLE
python 3.x compatibility: hamster2gtimelog: remove call to str.encode

### DIFF
--- a/contrib/hamster2gtimelog.py
+++ b/contrib/hamster2gtimelog.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2.7
+#!/usr/bin/python
 # Copyright (c) 2012 gocept gmbh & co. kg
 # See also LICENSE.txt
 
@@ -125,7 +125,7 @@ def main():
                       help=u'Print records until DATE (default: %(default)s)')
     args = argp.parse_args()
     facts = Facts(args.database, args.start, args.end)
-    sys.stdout.write(facts.render().encode('UTF-8'))
+    sys.stdout.write(facts.render())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Use the local system-provided `python` binary in a version-agnostic manner.

This _should_ be safe for existing Python 2.7 platforms, I think, thanks to [`Facts.render` returning a `unicode` string](https://github.com/gocept/gocept.gtimelog/blob/4e7dcbf42aa604d81502cfcc6795c9b2e06124e4/contrib/hamster2gtimelog.py#L72); redundant/the default for Python 3.x.

I've tested this locally for Python 2.7 and Python 3.9 and it resulted in an identical `gtimelog`-formatted output.

Contributes towards #5.