### PR TITLE
Fix gtl-progress

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,25 +112,23 @@ The following settings have to be set::
 
     ``engagement = 201, 140, 161, 140, 133, 154, 154, 154, 154, 147, 154, 161``
 
-- holidays: a list of iso dates which should be treated as holidays
+- holidays: a list of iso dates which should be treated as holidays::
 
-    .. code_block::
-
-      holidays =
-        2021-01-01
-        2021-01-06
-        2021-04-02
-        2021-04-04
-        2021-04-05
-        2021-05-01
-        2021-05-13
-        2021-05-23
-        2021-05-24
-        2021-10-03
-        2021-10-31
-        2021-12-24
-        2021-12-25
-        2021-12-26
+    holidays =
+      2021-01-01
+      2021-01-06
+      2021-04-02
+      2021-04-04
+      2021-04-05
+      2021-05-01
+      2021-05-13
+      2021-05-23
+      2021-05-24
+      2021-10-03
+      2021-10-31
+      2021-12-24
+      2021-12-25
+      2021-12-26
 
 gtl-updatetasks
 +++++++++++++++

--- a/README.rst
+++ b/README.rst
@@ -88,9 +88,9 @@ There is the possibility to enable bash completion, see
 gtl-progress
 ++++++++++++
 
-``gtl-progres`` can generate a report of the last time spans. It combines a daily
-report with a weekly, monthly, and yearly report with respect to the
-``engagement`` setting in ``~/.gtimelog/gtimelogrc``.::
+``gtl-progress`` can generate a report of the last time spans. It combines a
+daily report with a weekly, monthly, and yearly report with respect to the
+``engagement`` and ``holidays`` setting in ``~/.gtimelog/gtimelogrc``.::
 
   2021-04-07 report for username (Wed, week 14)
 
@@ -105,6 +105,32 @@ report with a weekly, monthly, and yearly report with respect to the
   Overtime this year:          -32 hours  5 min
 
   Time left at work:           7 hours 30 min (until 15:20)
+
+The following settings have to be set::
+
+- engagement: a comma separated list of monthly hours required to work
+
+    ``engagement = 201, 140, 161, 140, 133, 154, 154, 154, 154, 147, 154, 161``
+
+- holidays: a list of iso dates which should be treated as holidays
+
+    .. code_block::
+
+      holidays =
+        2021-01-01
+        2021-01-06
+        2021-04-02
+        2021-04-04
+        2021-04-05
+        2021-05-01
+        2021-05-13
+        2021-05-23
+        2021-05-24
+        2021-10-03
+        2021-10-31
+        2021-12-24
+        2021-12-25
+        2021-12-26
 
 gtl-updatetasks
 +++++++++++++++

--- a/src/gocept/gtimelog/core.py
+++ b/src/gocept/gtimelog/core.py
@@ -3,6 +3,7 @@
 
 from gocept.gtimelog.util import different_days
 from gocept.gtimelog.util import format_duration_long
+from gocept.gtimelog.util import parse_date
 import base64
 import codecs
 import configparser
@@ -514,6 +515,9 @@ class Settings(object):
 
     engagement = []
 
+    # the holidays for the current year. used for gtl-progress
+    holidays = []
+
     hours = 8
     week_hours = 40
     virtual_midnight = datetime.time(2, 0)
@@ -541,6 +545,7 @@ class Settings(object):
         config.set('gtimelog', 'editor', self.editor)
         config.set('gtimelog', 'mailer', self.mailer)
         config.set('gtimelog', 'engagement', self.engagement)
+        config.set('gtimelog', 'holidays', self.holidays)
         config.set('gtimelog', 'hours', str(self.hours))
         config.set('gtimelog', 'week_hours', str(self.week_hours))
         config.set('gtimelog', 'virtual_midnight',
@@ -570,6 +575,9 @@ class Settings(object):
         self.engagement = config.get('gtimelog', 'engagement')
         if self.engagement:
             self.engagement = [int(e) for e in self.engagement.split(',')]
+        self.holidays = config.get('gtimelog', 'holidays')
+        if self.holidays:
+            self.holidays = [parse_date(e) for e in self.holidays.split()]
         self.hours = config.getfloat('gtimelog', 'hours')
         self.week_hours = config.getfloat('gtimelog', 'week_hours')
         self.virtual_midnight = gocept.gtimelog.util.parse_time(

--- a/src/gocept/gtimelog/progress.py
+++ b/src/gocept/gtimelog/progress.py
@@ -31,36 +31,21 @@ class WithoutColors(object):
     BLACK = ''
 
 
-HOLIDAYS = [
-    date(2018, 1, 1),
-    date(2018, 1, 6),
-    date(2018, 3, 30),
-    date(2018, 4, 1),
-    date(2018, 4, 2),
-    date(2018, 5, 1),
-    date(2018, 5, 10),
-    date(2018, 5, 20),
-    date(2018, 5, 21),
-    date(2018, 10, 3),
-    date(2018, 10, 31),
-    date(2018, 12, 24),
-    date(2018, 12, 25),
-    date(2018, 12, 26),
-]
+# This is just the fallback, it can be configured via gtimlogrc.
+HOLIDAYS = []
 
 
-def get_businessdays_until_now():
+def get_businessdays_until_now(holidays=HOLIDAYS):
     """Return amount of businessdays of current month until today.
 
      This allows showing a progress over the current month and the
      current year.
     """
-
     now = datetime.now()
     businessdays = 0
     for i in range(1, now.day + 1):
         thisdate = date(now.year, now.month, i)
-        if thisdate.weekday() < 5 and thisdate not in HOLIDAYS:
+        if thisdate.weekday() < 5 and thisdate not in holidays:
             businessdays += 1
     return businessdays
 
@@ -130,7 +115,8 @@ def main():
     engagement = settings.engagement
     if engagement:
         expected = engagement[today.month - 1]
-        progress_expected = int(get_businessdays_until_now() * settings.hours)
+        progress_expected = int(get_businessdays_until_now(
+            holidays=settings.holidays) * settings.hours)
 
     print("Total work done this month: {colors.RED}{total_work} "
           "({total_percent} %){colors.BLACK} of "
@@ -157,7 +143,8 @@ def main():
             progress_engagement += settings.engagement[i - 1]
         else:
             progress_engagement += int(
-                get_businessdays_until_now() * settings.hours)
+                get_businessdays_until_now(
+                    holidays=settings.holidays) * settings.hours)
     engagement = sum(settings.engagement)
 
     print("Total work done this year:  {colors.RED}{total_work} "

--- a/src/gocept/gtimelog/tests/test_util.py
+++ b/src/gocept/gtimelog/tests/test_util.py
@@ -10,6 +10,7 @@ from gocept.gtimelog.util import different_days
 from gocept.gtimelog.util import format_duration
 from gocept.gtimelog.util import format_duration_long
 from gocept.gtimelog.util import format_duration_short
+from gocept.gtimelog.util import parse_date
 from gocept.gtimelog.util import parse_datetime
 from gocept.gtimelog.util import parse_time
 from gocept.gtimelog.util import uniq
@@ -50,6 +51,13 @@ class UtilityFunctions(unittest.TestCase):
         self.assertEqual(datetime(2005, 2, 3, 2, 13),
                          parse_datetime('2005-02-03 02:13'))
         self.assertRaises(ValueError, lambda: parse_datetime('xyzzy'))
+
+    def test_parse_date(self):
+        self.assertEqual(date(2021, 8, 25), parse_date('2021-08-25'))
+        self.assertRaises(ValueError, lambda: parse_date('2021-08-25 10:00'))
+        self.assertRaises(ValueError, lambda: parse_date('2021-08'))
+        self.assertRaises(ValueError, lambda: parse_date('25.08.2021'))
+        self.assertRaises(ValueError, lambda: parse_date('xyzzy'))
 
     def test_parse_time(self):
         self.assertEqual(time(2, 13), parse_time('02:13'))

--- a/src/gocept/gtimelog/tests/test_util.py
+++ b/src/gocept/gtimelog/tests/test_util.py
@@ -25,6 +25,10 @@ class UtilityFunctions(unittest.TestCase):
         self.assertEqual(' 0 h  0 min', format_duration(timedelta(0)))
         self.assertEqual(' 0 h  1 min', format_duration(timedelta(minutes=1)))
         self.assertEqual(' 1 h  0 min', format_duration(timedelta(minutes=60)))
+        self.assertEqual('-42 h 19 min', format_duration(
+            timedelta(seconds=-152340)))
+        self.assertEqual('42 h 19 min', format_duration(
+            timedelta(seconds=152340)))
 
     def test_format_short(self):
         self.assertEqual(' 0:00', format_duration_short(timedelta(0)))

--- a/src/gocept/gtimelog/util.py
+++ b/src/gocept/gtimelog/util.py
@@ -2,7 +2,6 @@
 # See also LICENSE.txt
 
 import datetime
-import re
 
 
 def calc_duration(duration):
@@ -69,16 +68,17 @@ def different_days(dt1, dt2, virtual_midnight):
 
 def parse_datetime(dt):
     """Parse a datetime instance from 'YYYY-MM-DD HH:MM' formatted string."""
-    m = re.match(r'^(\d+)-(\d+)-(\d+) (\d+):(\d+)$', dt)
-    if not m:
-        raise ValueError('bad date time: ', dt)
-    year, month, day, hour, min = list(map(int, m.groups()))
-    return datetime.datetime(year, month, day, hour, min)
+    return datetime.datetime.fromisoformat(dt)
 
 
 def parse_date(date):
     """Parse a date instance from 'YYYY-MM-DD' formatted string."""
     return datetime.date.fromisoformat(date)
+
+
+def parse_time(t):
+    """Parse a time instance from 'HH:MM' formatted string."""
+    return datetime.time.fromisoformat(t)
 
 
 def virtual_day(dt, virtual_midnight):
@@ -90,12 +90,3 @@ def virtual_day(dt, virtual_midnight):
     if dt.time() < virtual_midnight:     # assign to previous day
         return dt.date() - datetime.timedelta(1)
     return dt.date()
-
-
-def parse_time(t):
-    """Parse a time instance from 'HH:MM' formatted string."""
-    m = re.match(r'^(\d+):(\d+)$', t)
-    if not m:
-        raise ValueError('bad time: ', t)
-    hour, min = list(map(int, m.groups()))
-    return datetime.time(hour, min)

--- a/src/gocept/gtimelog/util.py
+++ b/src/gocept/gtimelog/util.py
@@ -1,11 +1,12 @@
 # Copyright (c) 2011 gocept gmbh & co. kg
 # See also LICENSE.txt
 
+from datetime import timedelta
 import datetime
 
 
-def calc_duration(duration):
-    """Calculates duration and returns tuple (h, m)
+def calc_duration(duration: timedelta):
+    """Calculate duration and returns tuple (h, m)
 
     m is always positive, the sign of h indicates positive or negative duration
     """
@@ -32,18 +33,18 @@ def calc_progress(settings, timelog, week_window):
     return week_done, week_exp, week_todo
 
 
-def format_duration(duration):
+def format_duration(duration: timedelta):
     """Format a datetime.timedelta with minute precision."""
     return '%2d h %2d min' % calc_duration(duration)
 
 
 # Propably do not need that. XXX GUI
-def format_duration_short(duration):
+def format_duration_short(duration: timedelta):
     """Format a datetime.timedelta with minute precision."""
     return '%2d:%02d' % calc_duration(duration)
 
 
-def format_duration_long(duration):
+def format_duration_long(duration: timedelta):
     """Format a datetime.timedelta with minute precision, long format."""
     h, m = calc_duration(duration)
     if h and m:
@@ -73,17 +74,17 @@ def different_days(dt1, dt2, virtual_midnight):
                                                              virtual_midnight)
 
 
-def parse_datetime(dt):
+def parse_datetime(dt: str):
     """Parse a datetime instance from 'YYYY-MM-DD HH:MM' formatted string."""
     return datetime.datetime.fromisoformat(dt)
 
 
-def parse_date(date):
+def parse_date(date: str):
     """Parse a date instance from 'YYYY-MM-DD' formatted string."""
     return datetime.date.fromisoformat(date)
 
 
-def parse_time(t):
+def parse_time(t: str):
     """Parse a time instance from 'HH:MM' formatted string."""
     return datetime.time.fromisoformat(t)
 

--- a/src/gocept/gtimelog/util.py
+++ b/src/gocept/gtimelog/util.py
@@ -5,8 +5,15 @@ import datetime
 
 
 def calc_duration(duration):
-    """Calculates duration and returns tuple (h, m)"""
-    return divmod((duration.days * 24 * 60 + duration.seconds // 60), 60)
+    """Calculates duration and returns tuple (h, m)
+
+    m is always positive, the sign of h indicates positive or negative duration
+    """
+    minutes = (duration.days * 24 * 60 + duration.seconds // 60)
+    hours = int(minutes / 60)
+    remainder = minutes / 60 - hours
+    minutes = abs(round(remainder * 60))
+    return (hours, minutes)
 
 
 def calc_progress(settings, timelog, week_window):

--- a/src/gocept/gtimelog/util.py
+++ b/src/gocept/gtimelog/util.py
@@ -76,6 +76,11 @@ def parse_datetime(dt):
     return datetime.datetime(year, month, day, hour, min)
 
 
+def parse_date(date):
+    """Parse a date instance from 'YYYY-MM-DD' formatted string."""
+    return datetime.date.fromisoformat(date)
+
+
 def virtual_day(dt, virtual_midnight):
     """Return the "virtual day" of a timestamp.
 


### PR DESCRIPTION
With `gtl-progess` it is possible to calculate the working progress over the last week/month/year and get a overtime based on the logged hours. 

This PR fixes the gtl-progress skript multiple ways:  
1. It allows to read the holidays needed to calculate the time needed to work correctly from gtimelogrc, as the source code hat to be adapted every year otherwise. 
2. Use the new `datetime.*.fromisoformat()` functions introduced in Python 3.7
3. Calculate the actual over time correctly. Negative times have been calculated wrong 
* 5h - 3h 26 m = 2h 26m, correct would be 1h 34m 