### PR TITLE
Fix collmex tasks download

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ Features
 
 - Add support for Python 3.7, 3.8, 3.9.
 
+Bug fixes
++++++++++
+
+- Fix collmex tasks download: Probably due to an Collmex API change the task
+  list was empty when newly downloaded.
+
 
 2.0 (2021-04-07)
 ----------------

--- a/src/gocept/gtimelog/collmex.py
+++ b/src/gocept/gtimelog/collmex.py
@@ -193,7 +193,7 @@ class TaskList(gocept.gtimelog.core.TaskList):
 
                 if (project['Abgeschlossen'] != u'0'
                         or project['Inaktiv'] != u'0'
-                        or product['Inaktiv'] is not None):
+                        or product['Inaktiv'] != u'0'):
                     continue
                 if lang != 'de' and product and product['Bezeichnung Eng']:
                     task_desc = product['Bezeichnung Eng']

--- a/src/gocept/gtimelog/collmex.py
+++ b/src/gocept/gtimelog/collmex.py
@@ -199,9 +199,7 @@ class TaskList(gocept.gtimelog.core.TaskList):
                     task_desc = product['Bezeichnung Eng']
                 else:
                     task_desc = project['Satz Bezeichnung']
-                tasks.write((
-                    u'%s: %s\n' % (project['Bezeichnung'],
-                                   task_desc)).encode('utf-8'))
+                tasks.write((f'{project["Bezeichnung"]}: {task_desc}\n'))
 
     def reload(self):
         self.download()

--- a/src/gocept/gtimelog/collmex.py
+++ b/src/gocept/gtimelog/collmex.py
@@ -199,7 +199,7 @@ class TaskList(gocept.gtimelog.core.TaskList):
                     task_desc = product['Bezeichnung Eng']
                 else:
                     task_desc = project['Satz Bezeichnung']
-                tasks.write((f'{project["Bezeichnung"]}: {task_desc}\n'))
+                tasks.write(f'{project["Bezeichnung"]}: {task_desc}\n')
 
     def reload(self):
         self.download()


### PR DESCRIPTION
Probably due to an Collmex API change the task list was empty when newly downloaded.

According to http://www.collmex.de/c.cmx?1005,1,help,daten_importieren_produkt the value of `Inaktiv` is 0, 1, 2 or 3, so it is always not None.
Adapting the code to this requirement.

The changed code is untested and hard to test because it does way too much.
